### PR TITLE
Update all references to the GitHub organization: amzn -> amazon-ion

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout ion-c
         uses: actions/checkout@master
         with:
-          repository: amzn/ion-c
+          repository: amazon-ion/ion-c
           ref: master
           path: ion-c
 
       - name: Checkout ion-test-driver
         uses: actions/checkout@master
         with:
-          repository: amzn/ion-test-driver
+          repository: amazon-ion/ion-test-driver
           ref: master
           path: ion-test-driver
 
@@ -36,7 +36,7 @@ jobs:
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
           -i ion-c,${{ github.event.pull_request.head.repo.html_url }},${{ github.event.pull_request.head.sha }}
-          --replace ion-c,https://github.com/amzn/ion-c.git,$main
+          --replace ion-c,https://github.com/amazon-ion/ion-c.git,$main
 
       - name: Upload result
         uses: actions/upload-artifact@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = https://github.com/amzn/ion-tests.git
+	url = https://github.com/amazon-ion/ion-tests.git
 [submodule "googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/amzn/ion-c/issues), or [recently closed](https://github.com/amzn/ion-c/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/amazon-ion/ion-c/issues), or [recently closed](https://github.com/amazon-ion/ion-c/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amzn/ion-c/labels/help%20wanted) issues is a great place to start. 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amazon-ion/ion-c/labels/help%20wanted) issues is a great place to start. 
 
 
 ## Code of Conduct
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/amzn/ion-c/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/amazon-ion/ion-c/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Amazon Ion C
-A C implementation of the [Ion data notation](http://amzn.github.io/ion-docs).
+A C implementation of the [Ion data notation](https://amazon-ion.github.io/ion-docs).
 
-[![Build Status](https://travis-ci.org/amzn/ion-c.svg?branch=master)](https://travis-ci.org/amzn/ion-c)
+[![Build Status](https://travis-ci.org/amazon-ion/ion-c.svg?branch=master)](https://travis-ci.org/amazon-ion/ion-c)
 [![Build status](https://ci.appveyor.com/api/projects/status/x6xfom3x3hs3y945/branch/master?svg=true)](https://ci.appveyor.com/project/tgregg/ion-c-3akm7/branch/master)
-<a title="docs" href="https://amzn.github.io/ion-c"><img src="https://img.shields.io/badge/docs-api-green.svg"/></a>
+<a title="docs" href="https://amazon-ion.github.io/ion-c"><img src="https://img.shields.io/badge/docs-api-green.svg"/></a>
 
 ## Setup
 This repository contains a [git submodule](https://git-scm.com/docs/git-submodule)
@@ -13,7 +13,7 @@ The easiest way to clone the `ion-c` repository and initialize its `ion-tests`
 submodule is to run the following command.
 
 ```
-$ git clone --recursive https://github.com/amzn/ion-c.git ion-c
+$ git clone --recursive https://github.com/amazon-ion/ion-c.git ion-c
 ```
 
 Alternatively, the submodule may be initialized independently from the clone

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -578,7 +578,7 @@ iERR _ion_writer_text_write_double(ION_WRITER *pwriter, double value)
 #endif
 
         // TODO this is a terrible way to convert this!
-        // See: https://github.com/amzn/ion-c/issues/112
+        // See: https://github.com/amazon-ion/ion-c/issues/112
         // For now:
         // "If an IEEE 754 double-precision number is converted to a decimal string with at least
         //  17 significant digits, and then converted back to double-precision representation,
@@ -641,7 +641,7 @@ iERR _ion_writer_text_write_double_json(ION_WRITER *pwriter, double value) {
    case FP_SUBNORMAL:
 #  endif
         // TODO this is a terrible way to convert this!
-        // See: https://github.com/amzn/ion-c/issues/112
+        // See: https://github.com/amazon-ion/ion-c/issues/112
 
         // The '*' in the format string indicates `DBL_DIG - 1` should be used for the precision.
         // The precision is the number of digits allowed to the *right* of the decimal point.

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -119,9 +119,9 @@ std::vector<std::string> *skip_list() {
 
         add_to_skip(good_path, "subfieldVarUInt32bit.ion"); // NOTE: the implementation caps SIDs at 32 bits. This contains a SID that overflows.
 
-        add_to_skip(good_path, join_path("typecodes", "T6-large.10n")); // https://github.com/amzn/ion-c/issues/165
-        add_to_skip(good_path, join_path("typecodes", "T7-large.10n")); // https://github.com/amzn/ion-c/issues/166
-        add_to_skip(bad_path, join_path("typecodes", "type_6_length_0.10n")); // https://github.com/amzn/ion-c/issues/167
+        add_to_skip(good_path, join_path("typecodes", "T6-large.10n")); // https://github.com/amazon-ion/ion-c/issues/165
+        add_to_skip(good_path, join_path("typecodes", "T7-large.10n")); // https://github.com/amazon-ion/ion-c/issues/166
+        add_to_skip(bad_path, join_path("typecodes", "type_6_length_0.10n")); // https://github.com/amazon-ion/ion-c/issues/167
     }
     return &_skip_list;
 }

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -521,7 +521,7 @@ TEST(IonBinaryFloat, ReaderSupports32BitFloats) {
     int pos_inf_bits = 0x7F800000;
     float pos_inf = *((float *)&pos_inf_bits);
 
-    // See https://amzn.github.io/ion-docs/docs/binary.html#4-float
+    // See https://amazon-ion.github.io/ion-docs/docs/binary.html#4-float
     // "If L is 0, then the the value is 0e0 and representation is empty."
     test_ion_binary_reader_supports_32_bit_floats((BYTE *) "\xE0\x01\x00\xEA\x40", 5, 0.);
     // Positive 0 can also be written out with 4 bytes instead
@@ -658,7 +658,7 @@ TEST(IonBinaryFloat, WriterSupports32BitFloats) {
     float nan = *((float *)&nan_bits);
 
     // ion-c prefers to write positive zero as a zero-length float
-    // see: https://amzn.github.io/ion-docs/docs/binary.html#4-float
+    // see: https://amazon-ion.github.io/ion-docs/docs/binary.html#4-float
     test_ion_binary_writer_supports_32_bit_floats(0., "\xE0\x01\x00\xEA\x40", 5);
     test_ion_binary_writer_supports_32_bit_floats(-0., "\xE0\x01\x00\xEA\x44\x80\x00\x00\x00", 9);
     test_ion_binary_writer_supports_32_bit_floats(4.2, "\xE0\x01\x00\xEA\x44\x40\x86\x66\x66", 9);
@@ -695,7 +695,7 @@ void test_ion_binary_writer_supports_compact_floats(BOOL compact_floats, double 
 
 TEST(IonBinaryFloat, WriterSupportsCompactFloatsOption) {
     // ion-c prefers to write positive zero as a zero-length float, whether this option is enabled or not
-    // see: https://amzn.github.io/ion-docs/docs/binary.html#4-float
+    // see: https://amazon-ion.github.io/ion-docs/docs/binary.html#4-float
     test_ion_binary_writer_supports_compact_floats(TRUE, 0., "\xE0\x01\x00\xEA\x40", 5);
     test_ion_binary_writer_supports_compact_floats(FALSE, 0., "\xE0\x01\x00\xEA\x40", 5);
 

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -718,13 +718,13 @@ void test_partial_lob_read(const char *ion_text, ION_TYPE expected_tid, SIZE exp
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
-// regression test for https://github.com/amzn/ion-c/issues/188
+// regression test for https://github.com/amazon-ion/ion-c/issues/188
 TEST(IonTextClob, CanFullyReadClobUsingPartialReads) {
     test_partial_lob_read("{{ \"This is a CLOB of text.\" }}",
                        tid_CLOB, 23, "This is a CLOB of text.");
 }
 
-// regression test for https://github.com/amzn/ion-c/issues/188
+// regression test for https://github.com/amazon-ion/ion-c/issues/188
 TEST(IonTextBlob, CanFullyReadBlobUsingPartialReads) {
     test_partial_lob_read("{{ VGhpcyBpcyBhIEJMT0Igb2YgdGV4dC4= }}",
                        tid_BLOB, 23, "This is a BLOB of text.");
@@ -786,7 +786,7 @@ TEST(IonTextStruct, FailsOnFieldNameWithNoValueInMiddle) {
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
-// reproduction for amzn/ion-c#235
+// reproduction for amazon-ion/ion-c#235
 TEST(IonTextInt, BinaryLiterals) {
     const char *ion_text = "-0b100";
     hREADER  reader;

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -40,7 +40,7 @@ INSTANTIATE_TEST_CASE_P(IonTimestampParameterized, IonTimestamp, testing::Values
         std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))
 ));
 
-// regression for https://github.com/amzn/ion-c/issues/144
+// regression for https://github.com/amazon-ion/ion-c/issues/144
 TEST_P(IonTimestamp, ion_timestamp_to_time_t) {
     ION_TIMESTAMP timestamp;
     SIZE chars_used;


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Changes all references to the `amzn` org to be `amazon-ion` org instead.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
