### PR TITLE
Add missing macro usage to allow building with DEBUG defined

### DIFF
--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -606,7 +606,7 @@ iERR _ion_writer_text_write_double(ION_WRITER *pwriter, double value)
 }
 
 iERR _ion_writer_text_write_double_json(ION_WRITER *pwriter, double value) {
-   iERR err = IERR_OK;
+   iENTER;
    char image[64], *mark;
    int fpc = FLOAT_CLASS(value);
 

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -61,6 +61,7 @@ iERR ion_cli_command_process_traverse(IonEventWriterContext *writer_context, Ion
 }
 
 iERR ion_cli_close_reader(IonCliReaderContext *context, iERR err, IonEventResult *result) {
+    FN_DEF;
     ASSERT(context);
     ION_SET_ERROR_CONTEXT(&context->input_location, NULL);
     if (context->reader) {
@@ -236,6 +237,7 @@ iERR ion_cli_open_writer(IonCliCommonArgs *common_args, ION_CATALOG *catalog, IO
 
 iERR ion_cli_close_writer(IonEventWriterContext *context, ION_CLI_IO_TYPE output_type, ION_STRING *output, iERR err,
                           IonEventResult *result) {
+    FN_DEF;
     UPDATEERROR(ion_event_writer_close(context, result, err, output_type == IO_TYPE_MEMORY,
                                        (output == NULL) ? NULL : &output->value,
                                        (output == NULL) ? NULL : &output->length));

--- a/tools/cli/cli.h
+++ b/tools/cli/cli.h
@@ -23,6 +23,7 @@
 #include "ion_event_util.h"
 #include "ion_event_stream_impl.h"
 #include "ion_catalog_impl.h"
+#include "ion_helpers.h"
 
 #define ION_CLI_VERSION "1.0"
 #define ION_CLI_PNAME "ion"

--- a/tools/events/ion_event_util.cpp
+++ b/tools/events/ion_event_util.cpp
@@ -170,6 +170,7 @@ iERR ion_event_in_memory_writer_open(IonEventWriterContext *writer_context, ION_
 
 iERR ion_event_writer_close(IonEventWriterContext *writer_context, IonEventResult *result, iERR err, bool in_memory,
                             BYTE **bytes, SIZE *bytes_len) {
+    FN_DEF;
     ION_SET_ERROR_CONTEXT(&writer_context->output_location, NULL);
     if (writer_context->writer) {
         ION_NON_FATAL(ion_writer_close(writer_context->writer), "Failed to close writer.");


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The macro ecosystem that ion-c defines, includes the ability to get some diagnostic information when building with `DEBUG` defined. Currently neither the Debug, nor the Release build actual use `DEBUG`. The diagnostics provided may be useful for debugging issues in ion-c or ion-python. Since the current builds do not include the debug macros there were a couple of areas where variables like `__file__`, and `__line__` where not being defined due to a mismatch between failure macros, and enter macros.

This PR addresses those areas and corrects the build when DEBUG is defined.

Here is an example of the diagnostic messages when running unit tests:
```
[       OK ] IonTimestampOutOfRangeFractionParameterized/IonTimestampOutOfRangeFraction.WriterFailsOnOutOfRangeFraction/5 (0 ms)
[ RUN      ] IonTimestampOutOfRangeFractionParameterized/IonTimestampOutOfRangeFraction.WriterFailsOnOutOfRangeFraction/6

ERROR 10 [IERR_INVALID_TIMESTAMP] WITH MESSAGE 'Invalid fraction value.' AT LINE 176 IN ion_timestamp.c

ERROR 10 [IERR_INVALID_TIMESTAMP] WITH MESSAGE 'fraction seconds can't be greater than 1' AT LINE 854 IN ion_timestamp.c
[       OK ] IonTimestampOutOfRangeFractionParameterized/IonTimestampOutOfRangeFraction.WriterFailsOnOutOfRangeFraction/6 (0 ms)
[----------] 7 tests from IonTimestampOutOfRangeFractionParameterized/IonTimestampOutOfRangeFraction (1 ms total)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
