### PR TITLE
Fix user stream reading to carry out multiple handler calls when needed

### DIFF
--- a/test/test_ion_stream.cpp
+++ b/test/test_ion_stream.cpp
@@ -12,6 +12,7 @@
  * language governing permissions and limitations under the License.
  */
 
+#include <math.h>
 #include <gtest/gtest.h>
 #include "ion_event_util.h"
 #include <ionc/ion_types.h>
@@ -228,4 +229,107 @@ TEST(IonStream, WriteToUserStream) {
     ION_ASSERT_OK(ion_reader_close(reader));
 
     free(context.data);
+}
+
+typedef struct _ion_read_state {
+    uint8_t *in;
+    size_t in_size;
+    size_t read_offset;
+    size_t block_size;
+    int num_calls;
+} ION_READ_STATE;
+
+static iERR seek_on_userstream_handler(struct _ion_user_stream *pstream) {
+    ION_READ_STATE *state = (ION_READ_STATE *)pstream->handler_state;
+    state->num_calls++;
+
+    if (state->read_offset >= state->in_size) {
+        return IERR_EOF;
+    }
+
+    size_t incr = std::min(state->in_size - state->read_offset, state->block_size);
+    pstream->curr = &state->in[state->read_offset];
+    pstream->limit = pstream->curr + incr;
+    state->read_offset += incr;
+    return IERR_OK;
+}
+
+TEST(IonStream, SeekOnUserStreamReadsAllData) {
+    // This test ensures that given a user managed stream, the right amount of data is read in order to seek
+    // to a given location. This test is in response to github issue ion-c#318.
+    // We first read the start of the stream, moving past the version marker, and symbol table. Then we seek
+    // to offset 48, while reading 3 bytes at a time. This should skip the first struct at offset 40 and leave
+    // us on the second struct. Prior to the fix for #318, the user managed stream would not read enough data to
+    // reach offset 48.
+    const SIZE block_size = 3;
+    const int seek_to = 48;
+
+    // echo '{hello: "World"}{dest1: "here"}{dest2: "here"}{dest3: "here"}' | ion dump --format binary | xxd -i
+    uint8_t ION_DATA[] = {
+        /* 00 */ 0xe0, 0x01, 0x00, 0xea,                                           // Ion 1.0 Version Marker
+        /* 04 */ 0xee, 0xa2, 0x81, 0x83,                                           // '$ion_symbol_table'::
+        /* 08 */ 0xde, 0x9e,                                                       // {
+        /* 10 */ 0x86,                                                             //   'imports':
+        /* 11 */ 0x71, 0x03,                                                       //      $ion_symbol_table,
+        /* 13 */ 0x87,                                                             //      'symbols':
+        /* 14 */ 0xbe, 0x98,                                                       //        [
+        /* 16 */ 0x85, 0x68, 0x65, 0x6c, 0x6c, 0x6f,                               //          "hello",
+        /* 22 */ 0x85, 0x64, 0x65, 0x73, 0x74, 0x31,                               //          "dest1",
+        /* 28 */ 0x85, 0x64, 0x65, 0x73, 0x74, 0x32,                               //          "dest2",
+        /* 34 */ 0x85, 0x64, 0x65, 0x73, 0x74, 0x33,                               //          "dest3",
+                                                                                   //        ]
+                                                                                   // }
+        /* 40 */ 0xd7, 0x8a, 0x85, 0x57, 0x6f, 0x72, 0x6c, 0x64,                   // {'hello': "World"}
+        //       >XX< - - - Seeking to here.
+        /* 48 */ 0xd6, 0x8b, 0x84, 0x68, 0x65, 0x72, 0x65,                         // {'dest1': "here"}
+        /* 55 */ 0xda, 0x8c, 0x88, 0x6e, 0x6f, 0x77, 0x20, 0x68, 0x65, 0x72, 0x65, // {'dest2': "now here"}
+        /* 66 */ 0xda, 0x8d, 0x88, 0x68, 0x65, 0x72, 0x65, 0x20, 0x74, 0x6f, 0x6f, // {'dest3': "here too"}
+    };
+
+    hREADER reader;
+    ION_TYPE type = tid_none;
+    POSITION offset = 0;
+
+    ION_READ_STATE ion_read_file = {
+        .in = ION_DATA,
+        .in_size = sizeof(ION_DATA),
+        .read_offset = 0,
+        .block_size = block_size,
+        .num_calls = 0,
+    };
+
+    ion_reader_open_stream(&reader, &ion_read_file, seek_on_userstream_handler, NULL);
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type)); // read symbol table and version marker
+
+    ION_ASSERT_OK(ion_reader_seek(reader, seek_to, -1)); // Should seek to a struct.
+
+    // When we seek we'll try to read full pages until we reach the page where the seek location
+    // is. So after the previous seek call, the handler should have been called enough times to
+    // read all data, plus once to recognize EOF.
+    ASSERT_EQ(1 + ceil((double)sizeof(ION_DATA) / (double)block_size), ion_read_file.num_calls);
+
+    // Ensure that we're actually looking at a struct..
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(type, tid_STRUCT);
+
+    // Test our offset to make sure we are where we think we are..
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &offset));
+    ASSERT_LE(offset, ion_read_file.read_offset); // We shouldn't be beyond what we've read..
+    ASSERT_EQ(offset, seek_to);
+
+    // Step into the struct.. and make sure we can continue reading.
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(type, tid_STRING);
+
+    ION_STRING str = {0};
+    ion_reader_get_field_name(reader, &str);
+
+    char *c_str = ion_string_strdup(&str);
+    ASSERT_STREQ("dest1", c_str);
+
+    free(c_str);
+
+    ion_reader_close(reader);
 }

--- a/test/test_ion_stream.cpp
+++ b/test/test_ion_stream.cpp
@@ -99,7 +99,7 @@ TEST(IonStream, ContinuesOverPageBoundary) {
     ION_ASSERT_OK(ion_reader_close(reader));
     ION_ASSERT_OK(ion_stream_close(stream));
 
-    ASSERT_EQ(2, context.number_of_handler_invocations);
+    ASSERT_EQ(3, context.number_of_handler_invocations);
     ION_ASSERT_OK(ion_timestamp_parse(&expected, (char *)expected_str, (SIZE)strlen(expected_str), &chars_used, &g_IonEventDecimalContext));
     ION_ASSERT_OK(ion_timestamp_equals(&expected, &ts, &is_equal, &g_IonEventDecimalContext));
     ASSERT_TRUE(is_equal);


### PR DESCRIPTION
*Issue #, if available:* 318

*Description of changes:*
Prior to this PR when a user managed buffer is read with the intention of filling a page, the handler for the buffer is called only once. No information is provided to the handler in order to communicate how much data is needed.

This resulted in user managed buffers not correctly seeking and the reader falling out of sync with the underlying buffer. More details can be seen in issue #318.

This PR updates the `_ion_stream_fread` function to ensure that the user managed buffer handler is called enough times to fill the requested buffer, stopping early in the cases of error, or insufficient data.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
