### PR TITLE
Bug Fix: User managed stream data corruption.

### DIFF
--- a/ionc/ion_stream.c
+++ b/ionc/ion_stream.c
@@ -1824,8 +1824,10 @@ iERR _ion_stream_fread( ION_STREAM *stream, BYTE *dst, BYTE *end, SIZE *p_bytes_
                 } else { // No new data, so we break out.
                     break;
                 }
+            } else if (err != IERR_EOF) {
+                bytes_read = READ_ERROR_LENGTH;
+                break;
             } else {
-                // Break in the case of error, or EOF.
                 break;
             }
         }

--- a/ionc/ion_stream.c
+++ b/ionc/ion_stream.c
@@ -1808,11 +1808,12 @@ iERR _ion_stream_fread( ION_STREAM *stream, BYTE *dst, BYTE *end, SIZE *p_bytes_
             memcpy(dst, user_stream->curr, to_copy);
             user_stream->curr += to_copy;
             bytes_read += to_copy;
+            dst += to_copy;
         }
         // Next, if we still need more, call the handler to get more bytes
         while (bytes_read < needed) {
             err = (*(user_stream->handler))(user_stream);
-            if (err == IERR_OK) {
+            if (err == IERR_OK  && (user_stream->curr != NULL && user_stream->limit != NULL)) {
                 local_bytes_read = (SIZE)(user_stream->limit - user_stream->curr);
                 int to_copy = (local_bytes_read + bytes_read > needed) ? (needed - bytes_read) : local_bytes_read;
                 if (to_copy > 0) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR fixes two issues that were introduced with the recent fix for user managed streams.

The first is during the 'catch up' portion of `_ion_stream_fread`, where previously read data was copied into a new page. With the previous fix, the page's current pointer `dst` was not updated after the write causing subsequent reads to overwrite the data.

The second issue that was introduced is when a user managed stream handler returned an error, the error would result in zero bytes read, but no error was bubbled up. This would result in readers EOFing on error rather than identifying a read error.

This PR also adds better guards around data copies. I've noticed some handlers that set the buffer limit to NULL to signal data was not read. I think we need some more documentation on what is expected for the handlers.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
