### PR TITLE
Add version number to decNumber to ensure soft link creation

### DIFF
--- a/decNumber/CMakeLists.txt
+++ b/decNumber/CMakeLists.txt
@@ -31,6 +31,8 @@ target_include_directories(decNumber
 
 set_target_properties(decNumber
     PROPERTIES
+        VERSION "3.68"
+        SOVERSION "3.68"
         PUBLIC_HEADER "${DEC_PUB_HEADERS}")
 
 # ---


### PR DESCRIPTION

*Description of changes:*
Without a version the .so file is created directly without a link which will look something like this: `ionc/libionc.so -> libionc.so.1.1.2`
The missing link causes problems when building with yocto

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
