### PR TITLE
Fix empty symbol handling and tape growth in ion-bench serialize_all benchmark.

### DIFF
--- a/tools/ion-bench/src/cbor/libcbor.h
+++ b/tools/ion-bench/src/cbor/libcbor.h
@@ -150,6 +150,7 @@ namespace libcbor {
          void load_data(uint8_t *input, size_t in_size) override {
             struct cbor_load_result result;
             cbor_item_t *item = cbor_load(input, in_size, &result);
+            _tape.clear();
 
             if (result.error.code != CBOR_ERR_NONE) {
                printf("ERROR loading cbor data: %d\n", result.error.code);

--- a/tools/ion-bench/src/ion/ionc.h
+++ b/tools/ion-bench/src/ion/ionc.h
@@ -158,6 +158,7 @@ class IonC : public Library {
 
       BufferReader<format> reader(input, in_size);
       auto err = reader.next();
+      _tape.clear();
 
       int depth = 0;
       while (reader.current_type() != tid_EOF || reader.depth() > 0) {
@@ -226,6 +227,7 @@ class IonC : public Library {
       BufferWriter<format> writer(buffer, len, pretty);
       int depth = 0;
 
+      // printf("Starting Offset: %d\n", writer.bytes_written());
       for (auto &val : this->_tape) {
          // indent(depth * 3); print_iondata(val);
          if (val.field_name.has_value()) {
@@ -257,7 +259,6 @@ class IonC : public Library {
       }
       writer.flush();
       stats.serde_bytes += writer.bytes_written();
-      // printf("Bytes written: %d\n", writer.bytes_written());
       writer.close();
       return stats;
    }

--- a/tools/ion-bench/src/ion/ionc.h
+++ b/tools/ion-bench/src/ion/ionc.h
@@ -227,7 +227,6 @@ class IonC : public Library {
       BufferWriter<format> writer(buffer, len, pretty);
       int depth = 0;
 
-      // printf("Starting Offset: %d\n", writer.bytes_written());
       for (auto &val : this->_tape) {
          // indent(depth * 3); print_iondata(val);
          if (val.field_name.has_value()) {

--- a/tools/ion-bench/src/ion/reading.h
+++ b/tools/ion-bench/src/ion/reading.h
@@ -48,8 +48,8 @@ namespace ion {
 
          std::optional<std::string> field_name() const {
             ION_STRING ionstr = {0};
-            ion_reader_get_field_name(_reader, &ionstr);
-            if (ionstr.length > 0) {
+            iERR err = ion_reader_get_field_name(_reader, &ionstr);
+            if (err == IERR_OK) {
                std::string value((char *)ionstr.value, ionstr.length);
                return std::make_optional(value);
             }

--- a/tools/ion-bench/src/json/json-c.h
+++ b/tools/ion-bench/src/json/json-c.h
@@ -130,6 +130,7 @@ namespace jsonc {
 
          void load_data(uint8_t *input, size_t size) override {
             enum json_tokener_error jerr;
+            _tape.clear();
 
             json_tokener *tok = json_tokener_new();
             json_object *doc = json_tokener_parse_ex(tok, (const char *)input, size);

--- a/tools/ion-bench/src/json/yy.h
+++ b/tools/ion-bench/src/json/yy.h
@@ -132,6 +132,7 @@ class YYJson : public Library {
       void load_data(uint8_t *input, size_t in_size) override {
          yyjson_read_err err;
          auto doc = yyjson_read_opts((char *)input, in_size, 0, NULL, &err);
+         _tape.clear();
 
          if (doc != nullptr) {
             auto val = yyjson_doc_get_root(doc);

--- a/tools/ion-bench/src/msgpack/msgpack.h
+++ b/tools/ion-bench/src/msgpack/msgpack.h
@@ -122,6 +122,7 @@ namespace msgpack {
             msgpack_unpacked result;
             msgpack_unpack_return ret;
             size_t offset = 0;
+            _tape.clear();
 
             msgpack_unpacked_init(&result);
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR fixes two issues found in ion-bench's `serialize_all` benchmark.

 1. While testing the performance regression workflow one of the generated datasets used an empty symbol (`''`) as a field name. When the the ion benchmark was generating the tape from the generated data, an error in the benchmark's reader considered a >0 length symbol as an indicator that the symbol existed, rather than relying on the returned iERR.
 2. When generating the tape for serialization, the tape was not initially cleared. This resulted in the another representation of the dataset to be appended to an existing tape of the dataset, if/when google-benchmark ran another block of iterations. This PR clears the tape for each of the formats implemented.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
