### PR TITLE
Fix documentation generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,8 @@ jobs:
       - test_ubuntu_and_mac
       - test_amazon_linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Install Doxygen
         run: sudo apt-get install doxygen -y


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
At some point in the past few months the documentation generation job stopped working due to permissions. This might be related to issues we had when we moved to the amazon-ion org, when org level permissions changed, I'm not sure though.

This PR adds `content: write` permissions to the document generation Job, so that we can push doc changes.

Github now supports publishing to github pages via actions, an alternative to pushing to gh-pages branch, which might be worth looking into in order to see pros/cons, it feels gross to allow write access to a repo via GHA.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
