### PR TITLE
Fix several compiler warnings

### DIFF
--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -814,7 +814,7 @@ iERR _ion_reader_text_step_out(ION_READER *preader)
             break;
         default: {
             char error_message[ION_ERROR_MESSAGE_MAX_LENGTH];
-            snprintf(error_message, ION_ERROR_MESSAGE_MAX_LENGTH, "Unable to step out of unrecognized container type %s", text->_current_container);
+            snprintf(error_message, ION_ERROR_MESSAGE_MAX_LENGTH, "Unable to step out of unrecognized container type %p", text->_current_container);
             FAILWITHMSG(IERR_INVALID_STATE, error_message);
         }
     }
@@ -1231,7 +1231,7 @@ iERR _ion_reader_text_get_value_position(ION_READER *preader, int64_t *p_offset,
     if (preader->_eof) {
         offset = -1;
         line = -1;
-        p_col_offset = -1;
+        p_col_offset = (int32_t *)-1;
     }
     else {
         if (text->_annotation_start >= 0) {

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -417,7 +417,7 @@ TEST(IonBinaryInt, ReaderRejectsNegativeZeroMixedIntTwoByte) {
     test_ion_binary_write_from_reader_rejects_negative_zero_int((BYTE *)"\xE0\x01\x00\xEA\x31\x00", 6);
 }
 
-void test_ion_binary_reader_threshold_for_int64_as_big_int(BYTE *data, size_t len, char *actual_value) {
+void test_ion_binary_reader_threshold_for_int64_as_big_int(BYTE *data, size_t len, const char *actual_value) {
     hREADER reader;
     ION_TYPE type;
     int64_t value;
@@ -478,7 +478,7 @@ TEST(IonBinaryReader, ReaderNegativeThresholdForInt64) {
     // -2 ** 64
     test_ion_binary_reader_threshold_for_int64_as_big_int((BYTE *)"\xE0\x01\x00\xEA\x38\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 13, "-18446744073709551615");
     // -2 ** 63 fits as two's complement representation
-    test_ion_binary_reader_threshold_for_int64_as_int64((BYTE *)"\xE0\x01\x00\xEA\x38\x80\x00\x00\x00\x00\x00\x00\x00", 13, -9223372036854775808);
+    test_ion_binary_reader_threshold_for_int64_as_int64((BYTE *)"\xE0\x01\x00\xEA\x38\x80\x00\x00\x00\x00\x00\x00\x00", 13, 0x8000000000000000 /* -9223372036854775808 */);
 }
 
 void test_ion_binary_reader_requires_timestamp_fraction_less_than_one(BYTE *data, size_t len) {

--- a/test/test_ion_stream.cpp
+++ b/test/test_ion_stream.cpp
@@ -164,23 +164,23 @@ TEST(IonStream, WriteToUserStream) {
 
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
     ION_STRING fieldNameString;
-    ion_string_assign_cstr(&fieldNameString, "str_col1", strlen("str_col1"));
+    ion_string_assign_cstr(&fieldNameString, (char *)"str_col1", strlen("str_col1"));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &fieldNameString));
 
     ION_STRING value_string;
-    ion_string_assign_cstr(&value_string, "str_val1", strlen("str_val1"));
+    ion_string_assign_cstr(&value_string, (char *)"str_val1", strlen("str_val1"));
     ION_ASSERT_OK(ion_writer_write_string(writer, &value_string));
 
-    ion_string_assign_cstr(&fieldNameString, "str_col2", strlen("str_col2"));
+    ion_string_assign_cstr(&fieldNameString, (char *)"str_col2", strlen("str_col2"));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &fieldNameString));
 
-    ion_string_assign_cstr(&value_string, "str_val1", strlen("str_val1"));
+    ion_string_assign_cstr(&value_string, (char *)"str_val1", strlen("str_val1"));
     ION_ASSERT_OK(ion_writer_write_string(writer, &value_string));
 
-    ion_string_assign_cstr(&fieldNameString, "str_col3", strlen("str_col3"));
+    ion_string_assign_cstr(&fieldNameString, (char *)"str_col3", strlen("str_col3"));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &fieldNameString));
 
-    ion_string_assign_cstr(&value_string, "str_val1", strlen("str_val1"));
+    ion_string_assign_cstr(&value_string, (char *)"str_val1", strlen("str_val1"));
     ION_ASSERT_OK(ion_writer_write_string(writer, &value_string));
 
     ION_ASSERT_OK(ion_writer_finish_container(writer));

--- a/tools/cli/argtable/argtable3.c
+++ b/tools/cli/argtable/argtable3.c
@@ -385,7 +385,7 @@ static void merge(void* data, int esize, int i, int j, int k, arg_comparefn* com
     mpos = 0;
 
     /* Allocate storage for the merged elements. */
-    m = (char*)xmalloc(esize * ((k - i) + 1));
+    m = (char*)xmalloc((size_t)esize * (size_t)((k - i) + 1));
 
     /* Continue while either division has elements to merge. */
     while (ipos <= j || jpos <= k) {
@@ -422,7 +422,7 @@ static void merge(void* data, int esize, int i, int j, int k, arg_comparefn* com
     }
 
     /* Prepare to pass back the merged data. */
-    memcpy(&a[i * esize], m, esize * ((k - i) + 1));
+    memcpy(&a[i * esize], m, (size_t)esize * (size_t)((k - i) + 1));
     xfree(m);
 }
 

--- a/tools/ion-bench/src/ion/common.h
+++ b/tools/ion-bench/src/ion/common.h
@@ -29,7 +29,7 @@ namespace ion {
    };
 
    inline void print_iondata(const IonData &data) {
-      printf("[IONDATA] tpe:0x%.4X field_name:%s",
+      printf("[IONDATA] tpe:0x%.4lX field_name:%s",
             data.tpe,
             data.field_name.value_or("none").c_str()
       );

--- a/tools/ion-bench/src/ion/writing.h
+++ b/tools/ion-bench/src/ion/writing.h
@@ -227,7 +227,7 @@ iERR write(BufferWriter<F> &writer, const IonData &val) {
       WRITE_ION_TYPE(writer, tid_SYMBOL_INT, Symbol, val);
       WRITE_ION_TYPE(writer, tid_TIMESTAMP_INT, std::shared_ptr<ION_TIMESTAMP>, val);
       default:
-         printf("Attempt to write unknown type: %d\n", val.tpe);
+         printf("Attempt to write unknown type: %ld\n", val.tpe);
          break;
    }
    return err;

--- a/tools/ionizer/ionizer.c
+++ b/tools/ionizer/ionizer.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
     
 fail:// this is iRETURN expanded so I can set a break point on it
     if (g_ionizer_debug) {
-        fprintf(stderr, "\nionizer finished, returning err [%d] = \"%s\", %d\n", err, ion_error_to_str(err), (intptr_t)t);
+        fprintf(stderr, "\nionizer finished, returning err [%d] = \"%s\", %ld\n", err, ion_error_to_str(err), (intptr_t)t);
     }
 
     if (g_ion_debug_timer) {

--- a/tools/ionsymbols/ionsymbols.c
+++ b/tools/ionsymbols/ionsymbols.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     
 fail:// this is iRETURN expanded so I can set a break point on it
     if (g_debug) {
-        fprintf(stderr, "\nionsymbols finished, returning err [%d] = \"%s\", %d\n", err, ion_error_to_str(err), (intptr_t)t);
+        fprintf(stderr, "\nionsymbols finished, returning err [%d] = \"%s\", %ld\n", err, ion_error_to_str(err), (intptr_t)t);
     }
 
     if (g_timer) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR addresses the issues identified by GitHub's Code Scanning alerts, as well as a few others that are just a drop in the ocean of warnings ion-c currently spits out. I'm hoping to spend some time over the next few weeks cleaning up more, so hopefully this will be just the first PR in a series.

Pre-PR:
```
$ fgrep 'warning:' output.txt | wc -l
     301
```
Post-PR:
```
$ fgrep 'warning:' output.txt | wc -l
     280
```

### Some Explainations

#### Int & FILE * conversions
I added a couple of macros to `ion_stream.c` called `FD_TO_FILEP` and `FILEP_TO_FD`. The ION_STREAM struct contains a field `_fp` that is of type `FILE *`, but is also used to store an integer file descriptor. When converting a pointer to an integer, C99 6.3.2.3.6 comes into play:
> Any pointer type may be converted to an integer type. Except as previously specified, the result is implementation-defined. If the result cannot be represented in the integer type, the behavior is undefined. The result need not be in the range of values of any integer type.

On x86_64 systems, a pointer is 64-bit, and an int is 32-bit, so the operation generates a warning. When converting from the integer to the pointer, the compiler also emits a warning, my guess is because of the same rule. The macros add a `size_t` which is not a pointer, and is a 64-bit value so it allows conversion to/from an int without warning, and to/from a pointer since the sizes match.

#### Redundant looking `char *`'s
There are a few added type casts to strings that look redundant, such as `(char *)"str_col1"`. In C a string literal is considered a `char *`, at least up to C99. In C++11 (I think) C++ diverged from this idea and (rightfully) changed the string literal (which is usually kept read-only memory) to a `const char *`, a pointer to constant characters. Historically, most functions that take a string as an argument, consider the string to be `const char *`, but sometimes that is not the case, like with `ion_string_assign_cstr`, which takes a `char *` argument, even though no modification to the characters occur. So these type casts were used to stop the C++ compiler from complaining about dropping const, which rightfully could indicate a bug.


#### Integer Overflow in Computation
In `argtable3.c`, there is a calculation that involves multiple integers. The end result of the computation is used as a `size_t` argument to `xmalloc`. Implicit conversion from an int to size_t occurs in order to use the result as the argument, but that conversion occurs after the computation is complete. During the computation, it is possible that the integers involved, will overflow the integer storage, before the implicit conversion occurs. So I've added type casts to the values themselves so that each operation in the computation is considered a size_t. (This is all from the compiler's perspective, I don't think, in this situation, there's any chance that the argument parser could calculate memory requirements that exceed 32bit values)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
