### PR TITLE
Fix pattern in the performance regression detection workflow

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
-      - 'ionc/*'
+      - 'ionc/**'
 jobs:
   detect-regression:
     name: Detect Regression


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR fixes the path in the performance regression detection workflow. Previous to this PR the glob only matched changes directly under the `ionc/` directory. This PR adjusts the glob to match any path below `ionc/`.

Glob syntax documentation [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) for reference.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
