### PR TITLE
Fix support for ion-c used with add_subdirectory in parent project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,10 @@ set(IONC_FULL_VERSION ${CMAKE_PROJECT_VERSION})
 find_program(GIT_EXECUTABLE "git")
 add_custom_target(
    version
-   ${CMAKE_COMMAND} -D SRC=${CMAKE_SOURCE_DIR}/build_version.h.in
-                    -D DST=${CMAKE_BINARY_DIR}/build_version.h
+   ${CMAKE_COMMAND} -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/build_version.h.in
+                    -D DST=${CMAKE_CURRENT_BINARY_DIR}/build_version.h
                     -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
-                    -P ${CMAKE_SOURCE_DIR}/cmake/VersionHeader.cmake
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/VersionHeader.cmake
 )
 
 include(GNUInstallDirs)

--- a/cmake/VersionHeader.cmake
+++ b/cmake/VersionHeader.cmake
@@ -5,6 +5,7 @@ if (GIT_EXECUTABLE)
       OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
       RESULT_VARIABLE GIT_DESCRIBE_ERROR
       OUTPUT_STRIP_TRAILING_WHITESPACE
+      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
    )
    if (NOT GIT_DESCRIBE_ERROR)
       # Describe output will be in the form v<version>-<commits>-g<hash>[-dirty]

--- a/ionc/CMakeLists.txt
+++ b/ionc/CMakeLists.txt
@@ -67,8 +67,7 @@ target_include_directories(objlib
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../decNumber/include>
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}
-            ${CMAKE_BINARY_DIR}
-
+            ${CMAKE_CURRENT_BINARY_DIR}/../
 )
 
 add_dependencies(objlib version)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR fixes some variables used in the version header generation, that resulted in a cmake project not being able to include ion-c via `add_subdirectory`.

The variables originally used were build-wide binary and source directories. The fix changes them to more localized directories where the ion-c specific files would be located. In addition to writing the header to the wrong location, the git command used to generate the version would also run in the wrong directory gathering the wrong version, or no version at all. This was also fixed.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
