### PR TITLE
Make behavior of reading a null.bool match other null values in ion text

### DIFF
--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -1330,6 +1330,9 @@ iERR _ion_reader_text_read_bool(ION_READER *preader, BOOL *p_value)
     else if (text->_value_sub_type == IST_BOOL_FALSE) {
         *p_value = FALSE;
     }
+    else if ((text->_value_sub_type->flags & FCF_IS_NULL) != 0) {
+       FAILWITH(IERR_NULL_VALUE)
+    }
     else {
         FAILWITH(IERR_INVALID_STATE);
     }


### PR DESCRIPTION
*Issue #, if available:* #330

*Description of changes:*
Prior to this PR reading a null bool using a text reader would result in an `IERR_INVALID_STATE`, which does not communicate the actual issue, and deviates from the behavior of other Ion values.

This PR handles the specific case of `null.bool` and returns an `IERR_NULL_VALUE`.

Thanks to @ezabes for finding and reporting this issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
