### PR TITLE
Update ion_debug_has_tracing to support strict function prototypes

### DIFF
--- a/ionc/include/ionc/ion_debug.h
+++ b/ionc/include/ionc/ion_debug.h
@@ -90,7 +90,7 @@ extern "C" {
 /** DEPRECATED - use the accessor functions below. */
 GLOBAL BOOL g_ion_debug_tracing INITTO(FALSE);
 
-ION_API_EXPORT BOOL ion_debug_has_tracing();
+ION_API_EXPORT BOOL ion_debug_has_tracing(void);
 ION_API_EXPORT void ion_debug_set_tracing(BOOL state);
 
 #ifdef __cplusplus

--- a/ionc/ion_debug.c
+++ b/ionc/ion_debug.c
@@ -18,7 +18,7 @@
 
 #include <ionc/ion_debug.h>
 
-BOOL ion_debug_has_tracing()
+BOOL ion_debug_has_tracing(void)
 {
 	return g_ion_debug_tracing;
 }


### PR DESCRIPTION
Issue 341

*Description of changes:*
Updates ion_debug_has_tracing declaration and definition to have a void parameter. This allows projects with strict prototyping enabled to include ion-c.
