### PR TITLE
Fix MacOS build & test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,12 +103,6 @@ jobs:
           fetch-depth: 50
       - name: Create git config # Fixes an issue where git refuses to work due to dubious permissions.
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      # This step should fix an issue with building on macos with gcc, and xcode 14.0,
-      # and should be removed once 14.1 is made default.
-      - name: Fix for XCode 14.0
-        if: runner.os == 'macOS'
-        run: |
-          echo "DEVELOPER_DIR=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
       - name: Build Debug
         id: build_debug
         run: ./build-debug.sh


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR removes a previously added configuration that forced the use of Xcode 14.1 that was put in place due to an issue with gcc that occurred in 14.0, while Github runners were defaulting to 14.0. Xcode 14.0 has been removed from the runner images, so the build is now failing.

After this PR, builds will return to using the default Xcode.


> NOTE: Both amazon linux builds are failing due to a node version update (PR incoming); ion-test-driver is failing and a fix has been posted in #344.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
