### PR TITLE
Fix issue with ion-test-driver

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -20,6 +20,11 @@ jobs:
           ref: master
           path: ion-test-driver
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Set up python3 env
         run: python3 -m venv ion-test-driver/venv && . ion-test-driver/venv/bin/activate
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR duplicates the change used in amazon-ion/ion-java#875 to address an issue with pip 22.0, by forcing a python install which updates pip to the latest version.


> NOTE: Both amazonlinux builds are failing due to a node version change (PR incoming); The MacOS build is failing due to the removal of Xcode 14.1 (Fixed with #343)
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
