### PR TITLE
Fix amazonlinux 1 & 2 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,10 @@ jobs:
       LDFLAGS: ${{ matrix.compiler.ldflags }}
       UBSAN_OPTIONS: "print_stacktrace=1"
       ASAN_OPTIONS: "halt_on_error=0"
+      # Tell GHA to force the use of node16. This will only work while node16 exists in the GHA runners,
+      # GitHub is moving to node20 (now default) and will eventually remove node16 entirely from the runner.
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       # Amazon Linux needs a newer version of git installed for actions/checkout@v2
       - name: Install Dependencies


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
GitHub has changed the default nodejs used for actions to node20, which requires a more recent glibc than amazonlinux 1 & 2 have. This PR uses GH provided env variables to force the runner to use node16 which will work with amazonlinux 1 & 2.

Amazon Linux 2 was supposed to be EOL'd a year ago, but support was extended until June of 2025.
Amazon Linux 1 has been EOL'd since Jan 1st 2024, after also being extended.

Node16 will probably be removed from the GHA runner before Amazon Linux 2 is EOL'd, so we'll have to determine if we can work around it, or if we should just move everything over to Amazon Linux 2023.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
