### PR TITLE
Adjust ASSERTs to allow zero length LOB reads

### DIFF
--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1754,7 +1754,7 @@ iERR _ion_reader_read_lob_bytes_helper(ION_READER *preader, BOOL accept_partial,
 
     ASSERT(preader);
     ASSERT(p_buf);
-    ASSERT(buf_max);
+    ASSERT(buf_max >= 0);
     ASSERT(p_length);
 
     switch(preader->type) {

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -1950,7 +1950,7 @@ iERR _ion_reader_text_read_lob_bytes(ION_READER *preader, BOOL accept_partial, B
 
     ASSERT(preader);
     ASSERT(p_buf);
-    ASSERT(buf_max);
+    ASSERT(buf_max >= 0);
     ASSERT(p_length);
 
     if (text->_state == IPS_ERROR 

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -635,7 +635,7 @@ TEST(IonBinaryBlob, CanFullyReadBlobUsingPartialReads) {
 
 // Simple test to ensure that if we supply a buffer size of 0 to ion_reader_read_lob_bytes, we don't assert. If the user
 // is reading values via the LOB size, and does not specifically handle 0-lengthed LOBs the reader shouldn't fail.
-TEST(IonBinaryBlob, CanReadZeroLengthBlobWithLobLength) {
+TEST(IonBinaryBlob, CanReadZeroLength) {
     hREADER reader;
     ION_TYPE type;
     const char *buffer = "\xE0\x01\x00\xEA\xA0";

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -657,6 +657,25 @@ TEST(IonTextBlob, CanReadBlob) {
                        tid_BLOB, 23, "This is a BLOB of text.");
 }
 
+TEST(IonTextBlob, CanReadZeroLength) {
+    hREADER reader;
+    ION_TYPE type;
+    const char *buffer = "{{}}";
+    char bytes[1]; // Shouldn't write any..
+
+    SIZE lob_size, bytes_read;
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, (BYTE*)buffer, 4, NULL));
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_BLOB, type);
+    ION_ASSERT_OK(ion_reader_get_lob_size(reader, &lob_size));
+    ASSERT_EQ(0, lob_size);
+    ION_ASSERT_OK(ion_reader_read_lob_bytes(reader, (BYTE*)bytes, lob_size, &bytes_read));
+    ASSERT_EQ(0, bytes_read);
+
+    ION_ASSERT_OK(ion_reader_close(reader));
+}
+
 void test_text_list(const char *ion_text) {
     ION_TYPE expected_tid = tid_LIST;
 


### PR DESCRIPTION
*Issue #, if available:* #331

*Description of changes:*
This PR adjusts a couple ASSERTs in order to allow users to provide a buffer length of zero when reading LOB data.

Previously, if a user had a zero-length LOB in their data, they would need to test for zero length before reading the LOB data. Providing a zero length when reading a lob would result in an infinite loop in release builds due to [this macro](https://github.com/amazon-ion/ion-c/blob/master/ionc/ion_internal.h#L89). This change allows the lob size to be used when reading, even if zero, potentially simplifying user code and definitely stopping surprise infinite loops.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
