### PR TITLE
Fix mechanism for getting package version, when git is not present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,14 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Profiling")
 endif()
 
 ## ion-c Build Version
-set(IONC_FULL_VERSION ${CMAKE_PROJECT_VERSION})
+set(IONC_FULL_VERSION "v${CMAKE_PROJECT_VERSION}-0-g000000")
 find_program(GIT_EXECUTABLE "git")
 add_custom_target(
    version
    ${CMAKE_COMMAND} -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/build_version.h.in
                     -D DST=${CMAKE_CURRENT_BINARY_DIR}/build_version.h
                     -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+                    -D IONC_FULL_VERSION=${IONC_FULL_VERSION}
                     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/VersionHeader.cmake
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Profiling")
 endif()
 
 ## ion-c Build Version
-set(IONC_FULL_VERSION "v${CMAKE_PROJECT_VERSION}-0-g000000")
+set(IONC_FULL_VERSION "v${CMAKE_PROJECT_VERSION}-0-g000000") # Format cmake project version to match git describe output
 find_program(GIT_EXECUTABLE "git")
 add_custom_target(
    version

--- a/cmake/VersionHeader.cmake
+++ b/cmake/VersionHeader.cmake
@@ -1,4 +1,3 @@
-set(IONC_FULL_VERSION "${CMAKE_PROJECT_VERSION}")
 if (GIT_EXECUTABLE)
    execute_process(
       COMMAND ${GIT_EXECUTABLE} describe --long --tags --dirty --match "v*"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Not too long ago an API was added in order to provide access to ion-c version information programmatically. During the build, a cmake script would query git for detailed information (revision sha, commits since tag, etc) to include in the API's data.

In the event that git is not available, or not enough git commits have been pulled down (clone --depth 1 for instance) this information is not present. The intention, was to lean on the cmake project's version in this case, but 2 issues prevented that from happening, which this PR fixes.

* Use of `CMAKE_PROJECT_VERSION` in a script that is not really executed as part of the project. This leads to an undefined version when git did not provide a version.
* Mismatch between the initialization of the project version, and how git would provide a long description. When git did/could not provide a version the default project version would not match the regex that parsed the version, resulting in build failure.

This PR passes the project version to the cmake script as a define, so that it is always present. It also fixes the default version to include filler that would normally be present in a `git describe`, so that the regex correctly matches and version header is generated.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
