### PR TITLE
Fix unsigned comparison which could fail due to numeric overflow

### DIFF
--- a/tools/events/ion_event_stream.cpp
+++ b/tools/events/ion_event_stream.cpp
@@ -1266,7 +1266,7 @@ size_t ion_event_stream_length(IonEventStream *stream, size_t index) {
     // NOTE: this will break if embedded streams themselves contain embedded streams. This should be explicitly
     // disallowed, as nested embedded streams are not a useful concept.
     size_t end_index = index;
-    while (stream->size() - end_index > 0 && stream->at(end_index++)->event_type != STREAM_END);
+    while (end_index < stream->size() && stream->at(end_index++)->event_type != STREAM_END);
     return  end_index - index;
 }
 


### PR DESCRIPTION
*Issue #, if available:* [Code Scanning 6](https://github.com/amazon-ion/ion-c/security/code-scanning/6)

*Description of changes:*
This PR addresses a comparison that was highlighted by gh code scanning. The original code contained:
```
stream->size() - end_index > 0
```
Where both `stream->size()` and `end_index` are of type `size_t`, which is unsigned. If `end_index` is larger than `stream->size()`, the result will be a positive value, due to numeric overflow. If this were to happen, `stream->at(end_index++)` would throw an exception, if exceptions are enabled, or abort the process if not.

This PR re-words the comparison to highlight that we expect `end_index` to be less than the stream's size, and lessen the chance of overflow potential if the condition were to change later.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
