### PR TITLE
Update MacOS build to use GCC 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
             compiler: { cc: 'gcc', cxx: 'g++' }
           - image: 'macos-latest'
             toolchain: gcc
-            compiler: { cc: 'gcc-11', cxx: 'g++-11' }
+            compiler: { cc: 'gcc-14', cxx: 'g++-14' }
     runs-on: ${{ matrix.image }}
     env:
       CC: ${{ matrix.compiler.cc }}

--- a/ionc/ion_allocation.c
+++ b/ionc/ion_allocation.c
@@ -92,7 +92,7 @@ iERR _ion_strdup(hOWNER owner, iSTRING dst, iSTRING src)
         dst->value = (BYTE *)ion_alloc_with_owner(owner, (is_empty) ? 1 : src->length);
         if (!dst->value) FAILWITH(IERR_NO_MEMORY);
     }
-    memcpy(dst->value, (is_empty) ? "\0" : src->value, (is_empty) ? 1 : src->length);
+    memcpy(dst->value, (is_empty) ? (BYTE*)"\0" : src->value, (is_empty) ? 1 : src->length);
 
     dst->length = src->length;
 

--- a/ionc/ion_internal.h
+++ b/ionc/ion_internal.h
@@ -109,7 +109,7 @@ GLOBAL BOOL _debug_on           INITTO(TRUE);
                                   (xb) = (*(xh)->_curr++);                      \
                                 }                                               \
                                 else {                                          \
-                                  IONCHECK(ion_stream_read_byte((xh), &(xb)));  \
+                                  IONCHECK(ion_stream_read_byte((xh), (int *)&(xb)));  \
                                 } while(FALSE)
 
 // macro for read_byte


### PR DESCRIPTION
*Issue #, if available:* actions/runner-images#10213

*Description of changes:*
Recently GCC 11 was removed from all MacOS images. This PR updates our build & test to use GCC 14.

Might be worth seeing if we can auto-populate the alias so we don't have to keep this in sync.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
