### PR TITLE
Update upload-artifact GHA to v4

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
           -i ion-c,${{ github.event.pull_request.head.repo.html_url }},${{ github.event.pull_request.head.sha }}
+          -I https://github.com/amazon-ion/ion-tests.git,main
           --replace ion-c,https://github.com/amazon-ion/ion-c.git,$main
 
       - name: Upload result

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -44,7 +44,7 @@ jobs:
           --replace ion-c,https://github.com/amazon-ion/ion-c.git,$main
 
       - name: Upload result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ion-test-driver-result.ion
           path: output/results/ion-test-driver-results.ion
@@ -59,7 +59,7 @@ jobs:
           ion-c,$main ion-c,$cur output/results/ion-test-driver-results.ion
 
       - name: Upload analysis report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: analysis-report.ion
           path: result.ion


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Version 1 and 2 of the upload-artifact, and download-artifact GHAs have been [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). This PR updates the actions used for ion-test-driver's report uploads to version 4.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
