### PR TITLE
Replace Assertion Failure with Error for Premature Container Ends

### DIFF
--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -370,7 +370,9 @@ iERR _ion_reader_binary_step_out(ION_READER *preader)
 
     if (curr_pos <= next_start) {
         // if we're at EOF then we should be spot on (curr_pos == next_start)
-        ASSERT(preader->_eof ? (curr_pos == next_start) : (curr_pos <= next_start));  
+        if (preader->_eof && curr_pos < next_start) {
+            FAILWITH(IERR_UNEXPECTED_EOF);
+        }
         to_skip = next_start - curr_pos;
         while (to_skip > 0) {
             if (to_skip > MAX_SIZE) {

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -149,6 +149,9 @@ begin:
         value_start = ion_stream_get_position(preader->istream); // the field name isn't part of the value
         ION_GET(preader->istream, type_desc_byte);               // read the TID byte
         if (type_desc_byte == EOF) {
+            if (preader->_depth > 0 && value_start < binary->_local_end) {
+                FAILWITH(IERR_EOF);
+            }
             goto at_eof;
         }
         

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -633,6 +633,18 @@ TEST(IonBinaryBlob, CanFullyReadBlobUsingPartialReads) {
             29, tid_BLOB, 23, "This is a BLOB of text.");
 }
 
+TEST(IonContainers, IncompleteContainerIsError) {
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_ASSERT_OK(ion_test_new_reader((BYTE*)"\xE0\x01\x00\xEA\xB6", 5, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_LIST, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_FAIL(ion_reader_step_out(reader));
+}
+
 // Simple test to ensure that if we supply a buffer size of 0 to ion_reader_read_lob_bytes, we don't assert. If the user
 // is reading values via the LOB size, and does not specifically handle 0-lengthed LOBs the reader shouldn't fail.
 TEST(IonBinaryBlob, CanReadZeroLength) {

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -636,12 +636,20 @@ TEST(IonBinaryBlob, CanFullyReadBlobUsingPartialReads) {
 TEST(IonContainers, IncompleteContainerIsError) {
     hREADER reader = NULL;
     ION_TYPE type;
-    ION_ASSERT_OK(ion_test_new_reader((BYTE*)"\xE0\x01\x00\xEA\xB6", 5, &reader));
+
+    // runs same steps against text to prove consistency
+    ION_ASSERT_OK(ion_test_new_reader((BYTE*)"[", 1, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_LIST, type);
     ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_FAIL(ion_reader_next(reader, &type));
+    ION_ASSERT_FAIL(ion_reader_step_out(reader));
+
+    ION_ASSERT_OK(ion_test_new_reader((BYTE*)"\xE0\x01\x00\xEA\xB2", 5, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
-    ASSERT_EQ(tid_EOF, type);
+    ASSERT_EQ(tid_LIST, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_FAIL(ion_reader_next(reader, &type));
     ION_ASSERT_FAIL(ion_reader_step_out(reader));
 }
 


### PR DESCRIPTION
This change replaces what is an assertion failure with a returned
error when the user attempts to step out of an Ion Container that
was not completed before the stream ended.

The issue is causing ion-python loads to hang for this case.

GH #355

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
