### PR TITLE
Update Amazon Linux version(s) used in Build & Test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,22 +16,12 @@ jobs:
         image: ['amazonlinux:2023']
         toolchain: [ "gcc", "clang" ]
         include:
-          - image: amazonlinux:2
+          - image: amazonlinux:2023
             toolchain: gcc
             compiler: { cc: 'gcc', cxx: 'g++', packages: 'gcc gcc-c++' }
-          - image: amazonlinux:2
+          - image: amazonlinux:2023
             toolchain: clang
-            compiler: { cc: 'clang', cxx: 'clang++', packages: 'clang gcc10-c++ compiler-rt' }
-          # amazonlinux:1's 'gcc'/'gcc-c++' packages install 4.8.5 which do not support C++14 which is needed
-          # by our googletest version. The clang package installs 3.6.2, which supports C++14, but does not support
-          # the sanitizers we want to use to capture issues during unit testing.
-          - image: amazonlinux:1
-            toolchain: gcc
-            compiler: { cc: 'gcc', cxx: 'g++', packages: "gcc72 gcc72-c++" }
-          # Need to set the target for clang, since the default target it is configured with differs from the gcc target installed that it depends on.
-          - image: amazonlinux:1
-            toolchain: clang
-            compiler: { cc: 'clang', cxx: 'clang++', packages: 'clang6.0', cxxflags: "-target x86_64-amazon-linux", cflags: "-target x86_64-amazon-linux" }
+            compiler: { cc: 'clang', cxx: 'clang++', packages: 'clang' }
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     env:
@@ -51,7 +41,7 @@ jobs:
       - name: Install Dependencies
         run: |
           yum install which git make cmake3 -y
-          ln -s `which cmake3` /usr/bin/cmake
+          if [ ! -e /usr/bin/cmake ]; then ln -s `which cmake3` /usr/bin/cmake; fi
       - name: Install ${{ matrix.compiler.cc }}
         run: yum install ${{ matrix.compiler.packages }} -y
       - name: Checkout Code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       # Run all jobs, even if one fails.  This makes it easier to gather debugging info for various platforms.
       fail-fast: false
       matrix:
-        image: ['amazonlinux:1', 'amazonlinux:2']
+        image: ['amazonlinux:2023']
         toolchain: [ "gcc", "clang" ]
         include:
           - image: amazonlinux:2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
         include:
           - image: amazonlinux:2023
             toolchain: gcc
-            compiler: { cc: 'gcc', cxx: 'g++', packages: 'gcc gcc-c++' }
+            compiler: { cc: 'gcc', cxx: 'g++', packages: 'gcc gcc-c++', cflags: '', cxxflags: '', ldflags: '' }
           - image: amazonlinux:2023
             toolchain: clang
-            compiler: { cc: 'clang', cxx: 'clang++', packages: 'clang' }
+            compiler: { cc: 'clang', cxx: 'clang++', packages: 'clang', cflags: '', cxxflags: '', ldflags: '' }
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     env:
@@ -37,21 +37,21 @@ jobs:
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      # Amazon Linux needs a newer version of git installed for actions/checkout@v2
+      # Amazon Linux needs a newer version of git installed for actions/checkout
       - name: Install Dependencies
         run: |
           yum install which git make cmake3 -y
-          if [ ! -e /usr/bin/cmake ]; then ln -s `which cmake3` /usr/bin/cmake; fi
+          if [ ! -e '/usr/bin/cmake' ]; then ln -s "$(which cmake3)" /usr/bin/cmake; fi
       - name: Install ${{ matrix.compiler.cc }}
         run: yum install ${{ matrix.compiler.packages }} -y
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-tags: true
           fetch-depth: 50 # we need to be able to fetch the tag that is nearest to the current commit.
       - name: Create git config # Fixes an issue where git refuses to work due to dubious permissions.
-        run: git config --system --add safe.directory $GITHUB_WORKSPACE
+        run: git config --system --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build Debug
         run: ./build-debug.sh
       - name: Test Debug
@@ -73,12 +73,12 @@ jobs:
         toolchain: ['gcc', 'clang']
         include:
           - toolchain: clang
-            compiler: { cc: 'clang', cxx: 'clang++' }
+            compiler: { cc: 'clang', cxx: 'clang++', cflags: '', cxxflags: '', ldflags: '' }
           - toolchain: gcc
-            compiler: { cc: 'gcc', cxx: 'g++' }
+            compiler: { cc: 'gcc', cxx: 'g++', cflags: '', cxxflags: '', ldflags: '' }
           - image: 'macos-latest'
             toolchain: gcc
-            compiler: { cc: 'gcc-14', cxx: 'g++-14' }
+            compiler: { cc: 'gcc-14', cxx: 'g++-14', cflags: '', cxxflags: '', ldflags: '' }
     runs-on: ${{ matrix.image }}
     env:
       CC: ${{ matrix.compiler.cc }}
@@ -90,13 +90,13 @@ jobs:
       ASAN_OPTIONS: "halt_on_error=0"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-tags: true
           fetch-depth: 50
       - name: Create git config # Fixes an issue where git refuses to work due to dubious permissions.
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build Debug
         id: build_debug
         run: ./build-debug.sh
@@ -120,7 +120,7 @@ jobs:
       - name: Install Doxygen
         run: sudo apt-get install doxygen -y
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Run Doxygen


### PR DESCRIPTION
*Issue #, if available:* #346

*Description of changes:*
Recently Github bumped up the minimum version of Node that could be used for github actions to Node 20. This change had the side effect of also bumping up the minimum supported version of glibc for actions to 2.27.

Prior to this PR, we used both Amazon Linux 1 and 2 for our build and test workflow. Unfortunately, AM1 uses glibc 2.17, and AM2 uses glibc 2.26.

Amazon Linux 1 was EOL'd Dec 31, 2023, and stopped receiving security updates Jan 1, 2024. After multiple extensions, Amazon Linux will be EOL'd June 30, 2026. Amazon's recommendation is to use Amazon Linux 2023, which will have full support until 2028.

This PR removes both Amazon Linux 1 and 2, and adds 2023 in their place. Once AL 2025 is available, we should add that as well.

In addition, this PR also cleans up the GHA job by fixing some `actionlint` warnings, which includes updating to checkout v4.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
