### PR TITLE
Add windows build to Build & Test workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
-          fetch-depth: 50
       - name: Build Debug
         run: |
           mkdir build64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,11 +123,13 @@ jobs:
           mkdir build64
           cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64"
           cmake --build build64 --config Debug
-      - name: Test debug
+      - name: Test Debug
         run: 'build64\test\Debug\all_tests.exe'
       - name: Build Release
         run: |
           cmake --build build64 --config Release
+      - name: Test Release
+        run: 'build64\test\Release\all_tests.exe'
 
   documentation:
     name: Generate Documentation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
         run: ./build/release/test/all_tests
 
   test_windows:
-    name: "Test (windows-latest)"
+    name: "Test (windows-latest, msvc)"
     runs-on: windows-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,7 @@ jobs:
         run: ./build/release/test/all_tests
 
   test_windows:
+    name: "Test (windows-latest)"
     runs-on: windows-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
           fetch-depth: 50
       - name: Build Debug
         run: |
-          mkdir build64 & pushd build64
+          mkdir build64
           cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64"
           cmake --build build64 --config Debug
       - name: Test debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,26 @@ jobs:
       - name: Test Release
         run: ./build/release/test/all_tests
 
+  test_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-tags: true
+          fetch-depth: 50
+      - name: Build Debug
+        run: |
+          mkdir build64 & pushd build64
+          cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64"
+          cmake --build build64 --config Debug
+      - name: Test debug
+        run: 'build64\test\Debug\all_tests.exe'
+      - name: Build Release
+        run: |
+          cmake --build build64 --config Release
+
   documentation:
     name: Generate Documentation
     needs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(IonC
         VERSION 1.1.3
         LANGUAGES CXX C)
 
-
 # we default to 'Release' build type
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
@@ -112,6 +111,9 @@ add_subdirectory(tools)
 if (IONC_BUILD_TESTS)
    if (NOT TARGET gtest_main)
       message("Using included google-test")
+      # Prevent googletest from linking against different versions of the C Runtime Library on
+      # Windows.
+      set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
       add_subdirectory(deps/google-test EXCLUDE_FROM_ALL)
    endif()
    add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,11 +8,6 @@ endif()
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DGTEST_DONT_DEFINE_SUCCEED=1 -DGTEST_DONT_DEFINE_FAIL=1")
 # Verbose parameterized names are disabled in debug configuration and on Windows. These don't
 # always integrate well with IDEs (e.g. CLion), but are nice to have from the command line.
-if (MSVC)
-    # Prevent googletest from linking against different versions of the C Runtime Library on
-    # Windows.
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-endif()
 
 add_executable(all_tests
     gather_vectors.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,9 +33,6 @@ add_executable(all_tests
     test_ion_reader_seek.cpp
 )
 
-set_property(TARGET all_tests PROPERTY CXX_STANDARD 98)
-
-
 target_include_directories(all_tests
         PRIVATE
             .

--- a/test/test_ion_stream.cpp
+++ b/test/test_ion_stream.cpp
@@ -291,11 +291,11 @@ TEST(IonStream, SeekOnUserStreamReadsAllData) {
     POSITION offset = 0;
 
     ION_READ_STATE ion_read_file = {
-        .in = ION_DATA,
-        .in_size = sizeof(ION_DATA),
-        .read_offset = 0,
-        .block_size = block_size,
-        .num_calls = 0,
+        /* .in           = */ ION_DATA,
+        /* .in_size      = */ sizeof(ION_DATA),
+        /* .read_offset  = */ 0,
+        /* .block_size   = */ block_size,
+        /* .num_calls    = */ 0,
     };
 
     ion_reader_open_stream(&reader, &ion_read_file, seek_on_userstream_handler, NULL);


### PR DESCRIPTION
*Issue #, if available:* #358, #255

*Description of changes:*
This PR adds a windows target to our Build & Test workflow, and addresses a couple issues that got in the way of successful windows builds while testing for this PR.

Some more information about the issues that were fixed can be found in #358. The first issue was due to GCC/Clang allowing named initializers (which are now a C++20 feature, but supported in C99) in C++, while MSVC does not.

The second issue was a result of refactoring dependencies a while ago, which resulted in google test being imported into the build tree earlier than a key option (`gtest_force_shared_crt`) to not be set until after google test was imported, resulting in it not taking effect, and causing a linking error. I've moved that setting up to the top-level CMakeLists.txt.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
