### PR TITLE
A pass to address warnings.

### DIFF
--- a/ionc/ion_catalog.c
+++ b/ionc/ion_catalog.c
@@ -262,7 +262,7 @@ iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name
 {
     iENTER;
     ION_SYMBOL_TABLE       **ppsymtab, *psymtab, *best = NULL;
-    ION_STRING               symtab_name, best_name, system_name;
+    ION_STRING               symtab_name, system_name;
     int32_t                  symtab_version, best_version, system_version;
     ION_COLLECTION_CURSOR    symtab_cursor;
 

--- a/ionc/ion_int.c
+++ b/ionc/ion_int.c
@@ -1234,7 +1234,6 @@ BOOL _ion_int_is_zero_bytes(const II_DIGIT *digits, SIZE len)
 
 SIZE _ion_int_highest_bit_set_helper(const ION_INT *iint)
 {
-    iENTER;
     II_DIGIT *digits, msd;
     SIZE    ii, len, bits = 0;
 
@@ -1712,7 +1711,6 @@ iERR _ion_int_sub_digit(II_DIGIT *digits
     II_DIGIT      digit;
     II_LONG_DIGIT temp, lvalue = (II_LONG_DIGIT)value;
     int           ii;
-    BOOL          carry = FALSE;
 
     ASSERT( digits );
     ASSERT( (value < II_BASE) && (value >= 0) );

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -1259,7 +1259,6 @@ iERR _ion_reader_text_get_value_position(ION_READER *preader, int64_t *p_offset,
 iERR _ion_reader_text_get_value_length(ION_READER *preader, SIZE *p_length)
 {
     iENTER;
-    ION_TEXT_READER  *text = &preader->typed_reader.text;
     SIZE              length;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
@@ -1417,7 +1416,6 @@ iERR _ion_reader_text_read_mixed_int_helper(ION_READER *preader)
 iERR _ion_reader_text_read_int32(ION_READER *preader, int32_t *p_value)
 {
     iENTER;
-    ION_TEXT_READER *text = &preader->typed_reader.text;
     int64_t          value64;
 
     IONCHECK(_ion_reader_text_read_int64(preader, &value64));
@@ -1691,7 +1689,6 @@ iERR _ion_reader_text_get_string_length(ION_READER *preader, SIZE *p_length)
 {
     iENTER;
     ION_TEXT_READER *text = &preader->typed_reader.text;
-    BYTE             terminator = '"';
     BOOL             eos_encountered;
 
     ASSERT(preader);
@@ -1785,7 +1782,6 @@ iERR _ion_reader_text_load_string_in_value_buffer(ION_READER *preader)
 {
     iENTER;
     ION_TEXT_READER *text = &preader->typed_reader.text;
-    BYTE             terminator = '"';
     BOOL             eos_encountered;
 
     ASSERT(preader);

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -1387,7 +1387,7 @@ just_another_char: // yes this is evil
 iERR _ion_scanner_read_cached_bytes(ION_SCANNER *scanner, BYTE *buf, SIZE len, SIZE *p_bytes_written)
 {
     iENTER;
-    BYTE *pb = buf, *sb = scanner->_pending_bytes_pos;
+    BYTE *pb = buf;
 
     ASSERT(buf);
     ASSERT(len > 0);

--- a/ionc/ion_stream.c
+++ b/ionc/ion_stream.c
@@ -1191,7 +1191,6 @@ iERR _ion_stream_open_helper(ION_STREAM_FLAG flags, SIZE page_size, ION_STREAM *
 iERR _ion_stream_flush_helper(ION_STREAM *stream)
 {
   iENTER;
-  POSITION position;
   SIZE     written, available;
   struct _ion_user_stream  *user_stream;
 
@@ -1540,7 +1539,6 @@ done:
 iERR _ion_stream_fetch_fill_page( ION_STREAM *stream, ION_PAGE *page, POSITION target_position )
 {
     iENTER;
-    ION_STREAM_PAGED *paged = PAGED_STREAM(stream);
     POSITION          page_read_position;
     BYTE             *dst, *end;
     SIZE              end_buf_offset, bytes_needed_user, bytes_needed_buffer, local_bytes_read;
@@ -1598,7 +1596,6 @@ iERR _ion_stream_fetch_fill_page( ION_STREAM *stream, ION_PAGE *page, POSITION t
 iERR _ion_stream_fseek( ION_STREAM *stream, POSITION target_position )
 {
     iENTER;
-    ION_STREAM_PAGED *paged = PAGED_STREAM(stream);
 
     ASSERT(stream);
     ASSERT(_ion_stream_is_paged(stream));
@@ -1766,7 +1763,6 @@ iERR _ion_stream_read_for_seek( ION_STREAM *stream, POSITION target_position )
 iERR _ion_stream_fread( ION_STREAM *stream, BYTE *dst, BYTE *end, SIZE *p_bytes_read)
 {
     iENTER;
-    ION_STREAM_PAGED *paged = PAGED_STREAM(stream);
     struct _ion_user_stream *user_stream = NULL;
     SIZE              local_bytes_read = 0, bytes_read = 0;
 
@@ -1870,7 +1866,6 @@ iERR _ion_stream_fread( ION_STREAM *stream, BYTE *dst, BYTE *end, SIZE *p_bytes_
 iERR _ion_stream_console_read( ION_STREAM *stream, BYTE *buf, BYTE *end, SIZE *p_bytes_read)
 {
     iENTER;
-    ION_STREAM_PAGED *paged = PAGED_STREAM(stream);
     BYTE             *dst = buf;
     int               c;
     SIZE              bytes_read;

--- a/test/ion_test_util.cpp
+++ b/test/ion_test_util.cpp
@@ -43,7 +43,7 @@ iERR ion_test_writer_get_bytes(hWRITER writer, ION_STREAM *ion_stream, BYTE **ou
     if (*len != (SIZE)pos) {
         UPDATEERROR(IERR_EOF);
     }
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 iERR ion_test_writer_write_symbol_sid(ION_WRITER *writer, SID sid) {

--- a/test/ion_test_util.h
+++ b/test/ion_test_util.h
@@ -22,7 +22,7 @@
 #define ION_ASSERT_FAIL(x) ASSERT_FALSE(IERR_OK == (x))
 
 #define INSTANTIATE_TEST_CASE_BOOLEAN_PARAM(instantiation_name) \
-    INSTANTIATE_TEST_CASE_P(instantiation_name, BinaryAndTextTest, ::testing::Bool())
+   INSTANTIATE_TEST_SUITE_P(instantiation_name, BinaryAndTextTest, ::testing::Bool())
 
 /**
  * Parameterized test fixture for tests that should be run for both text and binary.

--- a/test/test_ion_decimal.cpp
+++ b/test/test_ion_decimal.cpp
@@ -278,8 +278,9 @@ TEST(IonBinaryDecimal, ReaderAlwaysPreservesUpTo34Digits) {
 TEST(IonDecimal, WriteAllValues) {
     const char *text_decimal = "1.1999999999999999555910790149937383830547332763671875 -1d+123";
     ION_DECIMAL ion_decimal = {};
+    hREADER reader;
 
-    ION_DECIMAL_READER_INIT;
+    ION_ASSERT_OK(ion_test_new_text_reader(text_decimal, &reader));
     ION_DECIMAL_WRITER_INIT(FALSE);
 
     ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));

--- a/test/test_ion_extractor.cpp
+++ b/test/test_ion_extractor.cpp
@@ -245,7 +245,7 @@ iERR testCallback(hREADER reader, ION_EXTRACTOR_PATH_DESCRIPTOR *matched_path,
     ASSERTION_CONTEXT *assertion_context = (ASSERTION_CONTEXT *)user_context;
     assertion_context->assertion(reader, matched_path, assertion_context->path, control);
     assertion_context->num_matches++;
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 /**
@@ -254,7 +254,7 @@ iERR testCallback(hREADER reader, ION_EXTRACTOR_PATH_DESCRIPTOR *matched_path,
 iERR testCallbackBasic(hREADER reader, ION_EXTRACTOR_PATH_DESCRIPTOR *matched_path,
                        void *user_context, ION_EXTRACTOR_CONTROL *control) {
     iENTER;
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 /**

--- a/test/test_ion_reader_seek.cpp
+++ b/test/test_ion_reader_seek.cpp
@@ -34,7 +34,8 @@ public:
 };
 
 
-INSTANTIATE_TEST_CASE_P(IonReaderSeek, TextAndBinary, ::testing::Bool());
+/* INSTANTIATE_TEST_CASE_P(IonReaderSeek, TextAndBinary, ::testing::Bool()); */
+INSTANTIATE_TEST_SUITE_P(IonReaderSeek, TextAndBinary, ::testing::Bool());
 
 
 TEST_P(TextAndBinary, SeekToTopLevelScalar) {

--- a/test/test_ion_stream.cpp
+++ b/test/test_ion_stream.cpp
@@ -46,7 +46,7 @@ iERR ion_test_input_stream_handler(_ion_user_stream *stream) {
     else {
         stream->limit = stream->curr + remaining;
     }
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 iERR ion_test_new_paged_input_stream(ION_STREAM **p_stream, _test_in_memory_paged_stream_context *context) {
@@ -107,7 +107,6 @@ TEST(IonStream, ContinuesOverPageBoundary) {
 }
 
 TEST(IonStream, BufferTooSmall) {
-    iENTER;
     hWRITER writer = NULL;
     uint8_t buf[2]; // This buffer is too small to hold the output.
     ION_WRITER_OPTIONS options = { 0 };
@@ -134,7 +133,7 @@ iERR grow_buffer_if_necessary(_ion_user_stream *stream) {
         context->data = stream->curr;
         stream->curr += context->data_len;
     }
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 TEST(IonStream, WriteToUserStream) {

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -553,7 +553,8 @@ TEST_P(BinaryAndTextTest, ManuallyWritingImportWithNoNameIsIgnored) {
 }
 
 TEST_P(BinaryAndTextTest, ManuallyWritingAmbiguousImportFails) {
-    ION_SYMBOL_TEST_DECLARE_WRITER;
+    hWRITER writer;
+    ION_STREAM *stream;
 
     ION_STRING foo;
     ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
@@ -662,7 +663,8 @@ TEST_P(BinaryAndTextTest, ManuallyWriteSymbolTableAppendWithImportsSucceeds) {
 
 TEST_P(BinaryAndTextTest, SymbolTableGettersWithManualLSTInProgressReturnsPreviousSymbolTable) {
     // Test that the previous LST remains in scope until the end of the next LST struct.
-    ION_SYMBOL_TEST_DECLARE_WRITER;
+    hWRITER writer;
+    ION_STREAM *stream;
     ION_STRING sym1;
     ION_SYMBOL_TABLE *symbol_table_1, *symbol_table_2;
 
@@ -689,7 +691,8 @@ TEST_P(BinaryAndTextTest, SymbolTableGettersWithManualLSTInProgressReturnsPrevio
 
 TEST_P(BinaryAndTextTest, SymbolTableSetterWithManualLSTInProgressFails) {
     // Tests that an error is raised if the user tries to set the symbol table while manually writing one.
-    ION_SYMBOL_TEST_DECLARE_WRITER;
+    hWRITER writer;
+    ION_STREAM *stream;
     ION_SYMBOL_TABLE *symbol_table;
 
     ION_ASSERT_OK(ion_symbol_table_open(&symbol_table, NULL));
@@ -859,7 +862,8 @@ TEST_P(BinaryAndTextTest, WritingSymbolTokensWithUnknownTextFromCatalog) {
 
 TEST_P(BinaryAndTextTest, WritingInvalidIonSymbolFails) {
     // Tests that an invalid ION_SYMBOL (undefined text, import location, and local SID) raises an error.
-    ION_SYMBOL_TEST_DECLARE_WRITER;
+    hWRITER writer;
+    ION_STREAM *stream;
     ION_WRITER_OPTIONS writer_options;
     ION_SYMBOL symbol;
     memset(&symbol, 0, sizeof(ION_SYMBOL));

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -35,7 +35,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(IonTimestampParameterized, IonTimestamp, testing::Values(
+INSTANTIATE_TEST_SUITE_P(IonTimestampParameterized, IonTimestamp, testing::Values(
         std::make_tuple(std::string("2020-07-01T14:24:57-01:00"), -60, 1593617097, std::string("2020-07-01T15:24:57-00:00")),
         std::make_tuple(std::string("2020-07-01T14:24:57+00:00"),   0, 1593613497, std::string("2020-07-01T14:24:57-00:00")),
         std::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))
@@ -112,7 +112,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(IonTimestampHighPrecisionParameterized, IonTimestampHighPrecision, testing::Values(
+INSTANTIATE_TEST_SUITE_P(IonTimestampHighPrecisionParameterized, IonTimestampHighPrecision, testing::Values(
         std::make_tuple(std::string("123E-10"), std::string(".0000000123")),
         std::make_tuple(std::string("12.3E-9"), std::string(".0000000123")),
         std::make_tuple(std::string("1.23E-8"), std::string(".0000000123")),
@@ -138,7 +138,7 @@ TEST_P(IonTimestampHighPrecision, TextWriterCanWriteHighPrecisionFraction) {
     to_string[chars_used] = '\0';
 
     char expected[ION_TIMESTAMP_STRING_LENGTH + 1];
-    chars_used = sprintf(expected, "2007-01-01T12:59:59%s-00:00", expected_expanded_notation.c_str());
+    chars_used = snprintf(expected, ION_TIMESTAMP_STRING_LENGTH + 1, "2007-01-01T12:59:59%s-00:00", expected_expanded_notation.c_str());
     expected[chars_used] = '\0';
 
     ASSERT_STREQ(expected, to_string);
@@ -153,7 +153,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(IonTimestampOutOfRangeFractionParameterized, IonTimestampOutOfRangeFraction, testing::Values(
+INSTANTIATE_TEST_SUITE_P(IonTimestampOutOfRangeFractionParameterized, IonTimestampOutOfRangeFraction, testing::Values(
         "1E10",
         "10000000000E-1",
         "-1E-10",

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -467,6 +467,7 @@ TEST_P(GoodNonequivsVector, GoodNonequivs) {
     ION_TEST_VECTOR_COMPLETE;
 }
 
+#ifdef ION_PLATFORM_WINDOWS
 INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         GoodNonequivsVector,
@@ -475,10 +476,21 @@ INSTANTIATE_TEST_SUITE_P(
                 ::testing::Values(READ, ROUNDTRIP_TEXT, ROUNDTRIP_BINARY),
                 ::testing::Values(STREAM, BUFFER)
         )
-#if ION_TEST_VECTOR_VERBOSE_NAMES && !defined(ION_PLATFORM_WINDOWS)
+);
+#else
+INSTANTIATE_TEST_SUITE_P(
+        TestVectors,
+        GoodNonequivsVector,
+        ::testing::Combine(
+                ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_GOOD_NONEQUIVS)),
+                ::testing::Values(READ, ROUNDTRIP_TEXT, ROUNDTRIP_BINARY),
+                ::testing::Values(STREAM, BUFFER)
+        )
+#if ION_TEST_VECTOR_VERBOSE_NAMES
         , GoodVectorToString()
 #endif
 );
+#endif
 
 /**
  * Exercises bad vectors. Bad vectors must fail to parse in order to succeed the test.

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -267,7 +267,7 @@ cleanup:
     if (fstream) {
         fclose(fstream);
     }
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 void write_ion_event_result(IonEventResult *result, ION_CATALOG *catalog, std::string test_name) {
@@ -315,7 +315,7 @@ cleanup:
             free(written);
         }
     }
-    iRETURN;
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 #define ION_TEST_VECTOR_START \
@@ -345,7 +345,7 @@ TEST_P(GoodBasicVector, GoodBasic) {
 }
 
 #ifdef ION_PLATFORM_WINDOWS
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TestVectors,
     GoodBasicVector,
     ::testing::Combine(
@@ -355,7 +355,7 @@ INSTANTIATE_TEST_CASE_P(
     )
 );
 #else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         GoodBasicVector,
         ::testing::Combine(
@@ -395,7 +395,7 @@ INSTANTIATE_TEST_CASE_P(
     )
 );
 #else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         GoodEquivsVector,
         ::testing::Combine(
@@ -438,7 +438,7 @@ INSTANTIATE_TEST_CASE_P(
     )
 );
 #else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         GoodTimestampEquivTimelineVector,
         ::testing::Combine(
@@ -467,18 +467,7 @@ TEST_P(GoodNonequivsVector, GoodNonequivs) {
     ION_TEST_VECTOR_COMPLETE;
 }
 
-#ifdef ION_PLATFORM_WINDOWS
-INSTANTIATE_TEST_CASE_P(
-    TestVectors,
-    GoodNonequivsVector,
-    ::testing::Combine(
-        ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_GOOD_NONEQUIVS)),
-        ::testing::Values(READ, ROUNDTRIP_TEXT, ROUNDTRIP_BINARY),
-        ::testing::Values(STREAM, BUFFER)
-    )
-);
-#else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         GoodNonequivsVector,
         ::testing::Combine(
@@ -486,11 +475,10 @@ INSTANTIATE_TEST_CASE_P(
                 ::testing::Values(READ, ROUNDTRIP_TEXT, ROUNDTRIP_BINARY),
                 ::testing::Values(STREAM, BUFFER)
         )
-#if ION_TEST_VECTOR_VERBOSE_NAMES
+#if ION_TEST_VECTOR_VERBOSE_NAMES && !defined(ION_PLATFORM_WINDOWS)
         , GoodVectorToString()
 #endif
 );
-#endif
 
 /**
  * Exercises bad vectors. Bad vectors must fail to parse in order to succeed the test.
@@ -501,28 +489,17 @@ TEST_P(BadVector, Bad) {
     EXPECT_NE(IERR_OK, status) << test_name << " FAILED" << std::endl;
 }
 
-#ifdef ION_PLATFORM_WINDOWS
-INSTANTIATE_TEST_CASE_P(
-    TestVectors,
-    BadVector,
-    ::testing::Combine(
-        ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_BAD)),
-        ::testing::Values(STREAM, BUFFER)
-    )
-);
-#else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         BadVector,
         ::testing::Combine(
                 ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_BAD)),
                 ::testing::Values(STREAM, BUFFER)
         )
-#if ION_TEST_VECTOR_VERBOSE_NAMES
+#if ION_TEST_VECTOR_VERBOSE_NAMES && !defined(ION_PLATFORM_WINDOWS)
         , BadVectorToString()
 #endif
 );
-#endif
 
 // TODO the current bad/ vectors only test the reader. Additional bad/ tests could be created which test the writer.
 // This could be done by serializing a stream of IonEvents that are expected to produce an error when written as an

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -501,6 +501,7 @@ TEST_P(BadVector, Bad) {
     EXPECT_NE(IERR_OK, status) << test_name << " FAILED" << std::endl;
 }
 
+#ifdef ION_PLATFORM_WINDOWS
 INSTANTIATE_TEST_SUITE_P(
         TestVectors,
         BadVector,
@@ -508,10 +509,20 @@ INSTANTIATE_TEST_SUITE_P(
                 ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_BAD)),
                 ::testing::Values(STREAM, BUFFER)
         )
-#if ION_TEST_VECTOR_VERBOSE_NAMES && !defined(ION_PLATFORM_WINDOWS)
+);
+#else
+INSTANTIATE_TEST_SUITE_P(
+        TestVectors,
+        BadVector,
+        ::testing::Combine(
+                ::testing::ValuesIn(gather(FILETYPE_ALL, CLASSIFICATION_BAD)),
+                ::testing::Values(STREAM, BUFFER)
+        )
+#if ION_TEST_VECTOR_VERBOSE_NAMES
         , BadVectorToString()
 #endif
 );
+#endif
 
 // TODO the current bad/ vectors only test the reader. Additional bad/ tests could be created which test the writer.
 // This could be done by serializing a stream of IonEvents that are expected to produce an error when written as an

--- a/tools/ionizer/ionizer.c
+++ b/tools/ionizer/ionizer.c
@@ -35,7 +35,6 @@ int main(int argc, char **argv)
     FSTREAM_READER_STATE    *preader_state = NULL;
     FSTREAM_WRITER_STATE    *pwriter_state = NULL;
     ION_STRING               temp;
-    char                    *name = NULL;
     ION_TYPE                 t = (ION_TYPE)999;
     int32_t                  symbol_table_count = 0;
     int                      ii, non_argc = 0;

--- a/tools/ionsymbols/ionsymbols.c
+++ b/tools/ionsymbols/ionsymbols.c
@@ -41,7 +41,6 @@ int main(int argc, char **argv)
     hREADER                  hreader = 0;
     
     ION_STRING               temp;
-    char                    *name = NULL;
     ION_TYPE                 t = (ION_TYPE)999;
     int32_t                  symbol_table_count = 0;
     int                      ii, non_argc = 0;


### PR DESCRIPTION
> NOTE: Documenting changes via PR tour, will mark as ready when done.

*Issue #, if available:* n/a

*Description of changes:*
This PR is another pass at cleaning up some of the warnings we get in the build. This particular PR if focused mostly on `test/`, but does eliminate some low-hanging fruit warnings elsewhere.

A lot of the changes in `test/` are in `test_ion_symbol.cpp`. There were some macros setup to construct writers, and imports, that were re-used throughout the tests. This made the test creation easier, and once familiar with the macros everything made sense. Unfortunately, not all tests used all of the variables created in the macros, which lead to some unused variable warnings. I replaced the macros with functions to provide some of the functionality that the macros had, such as creating a new writer with particular settings, and populating the catalog with some imports. The rest of the macro functionality I moved into the test itself.

I think another pass could definitely be made to re-incorporate some of the patterns the macros had (such as providing a harness for testing, but allowing custom data retrieval and setup) to bring the test code closer to the original. Once the repos warnings are cleaned up I'd like to do that.

With the update of google-test, there might be some opportunities to rework some of the repo's tests as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
